### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/conorheffron/ronoc-packages/security/code-scanning/1](https://github.com/conorheffron/ronoc-packages/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations in the workflow, the `contents: read` permission is sufficient for reading repository files, and no write permissions are necessary.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build`) to limit permissions for that job only. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
